### PR TITLE
Add "Managed by Puppet" header to the tnsnames.ora file.

### DIFF
--- a/manifests/tnsnames.pp
+++ b/manifests/tnsnames.pp
@@ -57,6 +57,7 @@ define oradb::tnsnames(
       group          => $group,
       mode           => '0774',
       ensure_newline => true,
+      warn           => true,
     }
   }
 


### PR DESCRIPTION
This class module didn't not have the obligatory warning message at the top of the tnsnames.ora file.